### PR TITLE
fix #23 Last feed entry is duplicated infinitely

### DIFF
--- a/lib/template.ejs
+++ b/lib/template.ejs
@@ -108,13 +108,13 @@
       <script src="/infinite-scroll.js"></script>
       <script type="text/javascript">
 
-        var lastPageLoaded = null;
         var infScroll = new InfiniteScroll( '.container', {
           // options
           hideNav:'.pagination',
           append: '.item',
           history:false,
           prefill:true,
+          checkLastPage: '.hacky_link', // check this selector string exists, as it is only set if nextPageLink exists
           path: function(){
             // need to query this DOM my damn self
             var pageLinks = document.querySelectorAll('.hacky_link');
@@ -124,7 +124,7 @@
             }else{
               var finalLink = pageLinks[pageLinks.length-1].href;
               // make sure we don't load the same page twice
-              if (!finalLink || finalLink == window.location.href || finalLink == lastPageLoaded){
+              if (!finalLink || finalLink == window.location.href){
                 console.log('this was the last page');
                 return false;
               }else{


### PR DESCRIPTION
- checkLastPage option with selector '.hacky_link' inserted at InfiniteScroll creation
  - from the last page getNextPage() correctly returns null as feed.next = undefined
  - hidden DIV with '.hacky_link' is correctly not included for last page
  - InfinitScroll checks the presence of the '.hacky_link' selector and stops scrolling correctly if it is missing
- variable lastPageLoaded cleaned, because it was always null