### PR TITLE
Provide configurable path prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,20 +174,20 @@ app.get('/actor', logger, function(req,res){
 			}
 		  }
 		],
-		"id": `https://${apCryptoShit.getDomainName()}/actor`,
+		"id": `https://${apCryptoShit.getDomainName()}${apCryptoShit.getPathPrefix()}/actor`,
 		"type": "Application",
-		"inbox": `https://${apCryptoShit.getDomainName()}/actor/inbox`,
-		"outbox": `https://${apCryptoShit.getDomainName()}/actor/outbox`,
+		"inbox": `https://${apCryptoShit.getDomainName()}${apCryptoShit.getPathPrefix()}/actor/inbox`,
+		"outbox": `https://${apCryptoShit.getDomainName()}${apCryptoShit.getPathPrefix()}/actor/outbox`,
 		"preferredUsername": `${apCryptoShit.getDomainName()}`,
-		"url": `https://${apCryptoShit.getDomainName()}`,
+		"url": `https://${apCryptoShit.getDomainName()}${apCryptoShit.getPathPrefix()}`,
 		"manuallyApprovesFollowers": true,
 		"publicKey": {
-		  "id": `https://${apCryptoShit.getDomainName()}/actor#main-key`,
-		  "owner": `https://${apCryptoShit.getDomainName()}/actor`,
+		  "id": `https://${apCryptoShit.getDomainName()}${apCryptoShit.getPathPrefix()}/actor#main-key`,
+		  "owner": `https://${apCryptoShit.getDomainName()}${apCryptoShit.getPathPrefix()}/actor`,
 		  "publicKeyPem": apCryptoShit.getPublicKey()
 		},
 		"endpoints": {
-		  "sharedInbox": `https://${apCryptoShit.getDomainName()}/inbox`
+		  "sharedInbox": `https://${apCryptoShit.getDomainName()}${apCryptoShit.getPathPrefix()}/inbox`
 		}
 	  };
 	res.setHeader("content-type","application/activity+json; charset=utf-8")
@@ -201,18 +201,18 @@ app.get('/.well-known/webfinger', function(req,res){
 		var resJson = {
 			"subject": `acct:${domainName}@${domainName}`,
 			"aliases": [
-			  `https://${domainName}/actor`
+			  `https://${domainName}${apCryptoShit.getPathPrefix()}/actor`
 			],
 			"links": [
 			  {
 				"rel": "http://webfinger.net/rel/profile-page",
 				"type": "text/html",
-				"href": `https://${domainName}`
+				"href": `https://${domainName}${apCryptoShit.getPathPrefix()}`
 			  },
 			  {
 				"rel": "self",
 				"type": "application/activity+json",
-				"href": `https://${domainName}/actor`
+				"href": `https://${domainName}${apCryptoShit.getPathPrefix()}/actor`
 			  }
 			//   ,
 			//   {

--- a/lib/apCryptoShit.js
+++ b/lib/apCryptoShit.js
@@ -14,6 +14,10 @@ function getDomainName(){
     _precheck();
     return _domainName;
 }
+function getPathPrefix(){
+    _precheck();
+    return _path_prefix;
+}
 function getKeyId(){
     _precheck();
     return _keyId;
@@ -62,9 +66,10 @@ function _precheck(){
         process.exit(1)
     }
     _domainName = process.env.DOMAIN_NAME || "mastofeed.com"
+    _path_prefix = process.env.PATH_PREFIX || ""
 
-    _keyId=`https://${_domainName}/actor#main-key`
+    _keyId=`https://${_domainName}${_path_prefix}/actor#main-key`
     _precheckOk=true;
 }
 
-module.exports={sign,verify,getPublicKey,getPrivateKey,getDomainName,getKeyId}
+module.exports={sign,verify,getPublicKey,getPrivateKey,getDomainName,getPathPrefix,getKeyId}

--- a/lib/convertv2.js
+++ b/lib/convertv2.js
@@ -5,6 +5,7 @@ var timeAgo = require('timeago.js');
 const apGet = require('./apGet.js')
 const hour = 3600000;
 const sanitize = require("sanitize-html")
+const apCryptoShit = require("./apCryptoShit")
 
 // like Promise.all except returns null on error instead of failing all the promises
 async function promiseSome(proms){
@@ -66,6 +67,7 @@ module.exports = async function (opts) {
     var templateData = {
         opts: opts,// from the request
         meta: metaForUser(user),
+        pathPrefix: apCryptoShit.getPathPrefix() || "",
         items: await itemsForFeed(opts,user,feed),
         nextPageLink: getNextPage(opts,user,feed),
         isIndex: isIndex

--- a/lib/template.ejs
+++ b/lib/template.ejs
@@ -5,11 +5,11 @@
   <base target="_top" /><!-- this element is amazing-->
 
   <% if (opts.theme && opts.theme.toLowerCase() == 'light'){ %>
-  <link rel="stylesheet" href="/light.css"></link>
+  <link rel="stylesheet" href="<%= pathPrefix?`${pathPrefix}/light.css`:'/light.css' %>"></link>
   <% } else if (opts.theme && opts.theme.toLowerCase() == 'auto'){ %>
-    <link rel="stylesheet" href="/auto.css"></link>
+    <link rel="stylesheet" href="<%= pathPrefix?`${pathPrefix}/auto.css`:'/auto.css' %>"></link>
   <% } else { %>
-	  <link rel="stylesheet" href="/dark.css"></link>
+	  <link rel="stylesheet" href="<%= pathPrefix?`${pathPrefix}/dark.css`:'/dark.css' %>"></link>
   <% } %>
 
   <% if (opts.size){ %>
@@ -117,7 +117,7 @@
     <% } %>
 
     <% if ( isIndex ){ %>
-      <script src="/infinite-scroll.js"></script>
+      <script src="<%= pathPrefix?`${pathPrefix}/infinite-scroll.js`:'/infinite-scroll.js' %>"></script>
       <script type="text/javascript">
 
         var infScroll = new InfiniteScroll( '.container', {


### PR DESCRIPTION
We integrated the mastodon feed of our open source project on our website (see https://www.riot-os.org/) behind a reverse proxy. In previous versions of mastofeed we could just rewrite the path and it works. However, some updates to mastofeed make this impossible. Here is the, admittedly somewhat hacky, way how I solved this possible for now. In case you do not want to merge this: Maybe it helps someone else who has similar problems.

To test, one can add e.g. the following to a Caddy site:

```
	handle /mastofeed/* {
		uri strip_prefix /mastofeed
		reverse_proxy localhost:8080
	}

	rewrite /.well-known/webfinger /mastofeed{uri}
```
